### PR TITLE
Include functions from the deprecated cgi module

### DIFF
--- a/mimeparse.py
+++ b/mimeparse.py
@@ -39,7 +39,7 @@ def _parse_header(line):
         i = p.find('=')
         if i >= 0:
             name = p[:i].strip().lower()
-            value = p[i+1:].strip()
+            value = p[i + 1:].strip()
             if len(value) >= 2 and value[0] == value[-1] == '"':
                 value = value[1:-1]
                 value = value.replace('\\\\', '\\').replace('\\"', '"')

--- a/mimeparse.py
+++ b/mimeparse.py
@@ -9,6 +9,8 @@ class MimeTypeParseException(ValueError):
     pass
 
 
+# Vendored version of cgi._parseparam from Python 3.11 (deprecated and slated
+# for removal in 3.13)
 def _parseparam(s):
     while s[:1] == ';':
         s = s[1:]
@@ -22,6 +24,8 @@ def _parseparam(s):
         s = s[end:]
 
 
+# Vendored version of cgi.parse_header from Python 3.11 (deprecated and slated
+# for removal in 3.13)
 def _parse_header(line):
     """Parse a Content-type like header.
 


### PR DESCRIPTION
The stdlib `cgi` module is deprecated and going to be removed in Python 3.13. Currently, if you run `pytest` on any file that uses `mimeparse` you will see this deprecation warning:

~~~
========================================== warnings summary ===========================================
mimeparse.py:1
  /Users/st/p/python-mimeparse/mimeparse.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
~~~

Since mimeparse only depends on two (short) functions from the `cgi` module, I suggest to include them directly in the mimparse codebase. This will silence the warning and make sure mimeparse will continue to work with Python >= 3.13.

Edit: Source: https://github.com/python/cpython/blob/3.11/Lib/cgi.py#L226-L256