### PR TITLE
chore: Run pyupgrade --py38-plus, remove mentions of lower python versions

### DIFF
--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -12,13 +12,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.5"
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
-          - "pypy-3.7"
+          - "pypy-3.8"
 
       fail-fast: false
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Use **pip**:
 
     $ pip install python-mimeparse
 
-It supports Python 2.7, 3.4+ and PyPy.
+It supports Python 3.8+ and PyPy.
 
 Functions
 ---------
@@ -47,7 +47,7 @@ Choose the mime-type with the highest quality ("q") from a list of candidates.
 Testing
 -------
 
-Run the tests by typing: ``python mimeparse_test.py``. The tests require Python 2.6.
+Run the tests by typing: ``python mimeparse_test.py``.
 
 To make sure that the package works in all the supported environments, you can
 run **tox** tests:

--- a/mimeparse.py
+++ b/mimeparse.py
@@ -68,7 +68,7 @@ def parse_mime_type(mime_type):
     type_parts = full_type.split('/') if '/' in full_type else None
     if not type_parts or len(type_parts) > 2:
         raise MimeTypeParseException(
-            "Can't parse type \"{}\"".format(full_type))
+            f"Can't parse type \"{full_type}\"")
 
     (type, subtype) = type_parts
 

--- a/mimeparse_test.py
+++ b/mimeparse_test.py
@@ -20,19 +20,19 @@ __credits__ = ""
 class MimeParseTestCase(unittest.TestCase):
 
     def setUp(self):
-        super(MimeParseTestCase, self).setUp()
+        super().setUp()
         with open("testdata.json") as f:
             self.test_data = json.load(f)
 
     def _test_parse_media_range(self, args, expected):
         expected = tuple(expected)
         result = mimeparse.parse_media_range(args)
-        message = "Expected: '%s' but got %s" % (expected, result)
+        message = f"Expected: '{expected}' but got {result}"
         self.assertEqual(expected, result, message)
 
     def _test_quality(self, args, expected):
         result = mimeparse.quality(args[0], args[1])
-        message = "Expected: '%s' but got %s" % (expected, result)
+        message = f"Expected: '{expected}' but got {result}"
         self.assertEqual(expected, result, message)
 
     def _test_best_match(self, args, expected, description):
@@ -53,7 +53,7 @@ class MimeParseTestCase(unittest.TestCase):
         else:
             expected = tuple(expected)
             result = mimeparse.parse_mime_type(args)
-            message = "Expected: '%s' but got %s" % (expected, result)
+            message = f"Expected: '{expected}' but got {result}"
             self.assertEqual(expected, result, message)
 
     def test_parse_media_range(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ license_file = LICENSE
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -33,7 +31,7 @@ project_urls =
     Issue Tracker=https://github.com/falconry/python-mimeparse
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.8
 py_modules = mimeparse
 install_requires =
 tests_require =


### PR DESCRIPTION
Didn't touch the travis file. I'm guessing it should be removed.